### PR TITLE
Add simple swipe card PWA

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-# pwa-game-prototype
+# PWA Swipe Card Game
+
+This project is a simple progressive web app (PWA) built for Cloudflare Pages. The game presents a deck of cards that can be swiped left or right on mobile screens.
+
+## Gameplay
+1. The first card asks **"Would you like to enlist as Tzar?"**. Swipe right for yes or left for no. You must answer this card to continue.
+2. Depending on your answer, a shuffled deck of 20 questions for either **Tzar** or **Citizen** is displayed.
+3. Each card can be swiped right (yes) or left (no). After you answer, the next card slides into view.
+
+## Development
+All files are static and can be deployed directly on Cloudflare Pages.
+
+### Run locally
+Just open `index.html` in a modern browser. The service worker caches files for offline access.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Swipe Card Game</title>
+  <link rel="manifest" href="manifest.json">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div id="app">
+    <div class="card" id="current-card"></div>
+    <div class="card" id="next-card"></div>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,8 @@
+{
+  "name": "Swipe Card Game",
+  "short_name": "SwipeGame",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#ffffff"
+}

--- a/script.js
+++ b/script.js
@@ -1,0 +1,147 @@
+const introCard = "Would you like to enlist as Tzar?";
+
+const tzarCards = [
+  "Do you command the loyalty of the boyars?",
+  "Will you expand the realm's borders?",
+  "Do you trust your advisors completely?",
+  "Will you impose new taxes for the army?",
+  "Do you plan to build a grand palace?",
+  "Will you allow the printing press to flourish?",
+  "Will you send envoys to foreign courts?",
+  "Do you accept the church's authority?",
+  "Will you hold lavish feasts for the nobles?",
+  "Do you believe in absolute rule?",
+  "Will you create a new legal code?",
+  "Do you support exploration of distant lands?",
+  "Will you reform the military ranks?",
+  "Do you promise to protect the peasants?",
+  "Will you invite foreign architects?",
+  "Do you wish to strengthen the navy?",
+  "Will you host grand tournaments?",
+  "Do you plan to outlaw corruption?",
+  "Will you expand trade with the west?",
+  "Do you vow to crush all rebellions?"
+];
+
+const citizenCards = [
+  "Do you pay taxes willingly?",
+  "Will you join the village militia?",
+  "Do you trust the local officials?",
+  "Will you help build the town hall?",
+  "Do you support your neighbors in need?",
+  "Will you attend the harvest festival?",
+  "Do you pledge loyalty to the realm?",
+  "Will you learn a craft or trade?",
+  "Do you oppose harsh laws?",
+  "Will you keep traditions alive?",
+  "Do you seek fair treatment?",
+  "Will you barter with traveling merchants?",
+  "Do you care for the community well-being?",
+  "Will you assist in road repairs?",
+  "Do you report crimes to the guard?",
+  "Will you pay homage to the Tzar?",
+  "Do you stand for peaceful protests?",
+  "Will you educate your children?",
+  "Do you uphold the market rules?",
+  "Will you pray for the realm's prosperity?"
+];
+
+let deck = [];
+let answers = [];
+let index = 0;
+let state = 'intro';
+let animating = false;
+let currentSwipeDir = null;
+
+const currentEl = document.getElementById('current-card');
+const nextEl = document.getElementById('next-card');
+
+function shuffle(array) {
+  return array
+    .map(value => ({ value, sort: Math.random() }))
+    .sort((a, b) => a.sort - b.sort)
+    .map(({ value }) => value);
+}
+
+function showIntro() {
+  currentEl.textContent = introCard;
+  nextEl.classList.add('hidden');
+}
+
+function startGame(asTzar) {
+  deck = shuffle(asTzar ? tzarCards : citizenCards);
+  index = 0;
+  state = 'game';
+  currentEl.textContent = deck[index];
+  prepareNext();
+}
+
+function prepareNext() {
+  if (index + 1 < deck.length) {
+    nextEl.textContent = deck[index + 1];
+    nextEl.className = 'card enter-from-bottom';
+  } else {
+    nextEl.className = 'card hidden';
+  }
+}
+
+function handleAnswer(ans) {
+  if (state === 'intro') {
+    startGame(ans === 'yes');
+  } else {
+    answers.push({ q: deck[index], a: ans });
+    index++;
+    if (index >= deck.length) {
+      currentEl.textContent = 'The End';
+      nextEl.className = 'card hidden';
+      return;
+    }
+    currentEl.textContent = deck[index];
+    prepareNext();
+  }
+}
+
+function onTransitionEnd() {
+  if (!animating) return;
+  animating = false;
+  currentEl.className = 'card';
+  nextEl.classList.remove('center');
+  handleAnswer(currentSwipeDir === 'right' ? 'yes' : 'no');
+}
+
+function swipe(dir) {
+  if (animating) return;
+  currentSwipeDir = dir;
+  animating = true;
+  currentEl.classList.add(dir === 'right' ? 'move-right' : 'move-left');
+  nextEl.classList.remove('enter-from-bottom');
+  nextEl.classList.add('center');
+}
+
+let startX = 0;
+let startY = 0;
+const threshold = 30;
+
+currentEl.addEventListener('pointerdown', e => {
+  startX = e.clientX;
+  startY = e.clientY;
+});
+
+currentEl.addEventListener('pointerup', e => {
+  const dx = e.clientX - startX;
+  const dy = e.clientY - startY;
+  if (Math.abs(dx) > Math.abs(dy) && Math.abs(dx) > threshold) {
+    swipe(dx > 0 ? 'right' : 'left');
+  }
+});
+
+currentEl.addEventListener('transitionend', onTransitionEnd);
+
+showIntro();
+
+// Register service worker
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('service-worker.js');
+  });
+}

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,20 @@
+const CACHE_NAME = 'swipe-game-v1';
+const ASSETS = [
+  '/',
+  '/index.html',
+  '/style.css',
+  '/script.js',
+  '/manifest.json'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(ASSETS))
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(resp => resp || fetch(event.request))
+  );
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,61 @@
+html, body {
+  margin: 0;
+  padding: 0;
+  height: 100%;
+  overflow: hidden;
+  font-family: Arial, sans-serif;
+}
+
+#app {
+  position: relative;
+  height: 100%;
+  width: 100%;
+  background: #f0f0f0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.card {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 90%;
+  max-width: 400px;
+  height: 70%;
+  transform: translate(-50%, -50%);
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 4px 8px rgba(0,0,0,0.2);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  box-sizing: border-box;
+  text-align: center;
+  font-size: 1.3em;
+  user-select: none;
+  touch-action: none; /* to get pointer events */
+  transition: transform 0.3s ease-out;
+}
+
+.hidden {
+  display: none;
+}
+
+.move-left {
+  transform: translate(-150%, -50%) rotate(-15deg);
+}
+
+.move-right {
+  transform: translate(150%, -50%) rotate(15deg);
+}
+
+.enter-from-bottom {
+  transform: translate(-50%, 150%);
+}
+
+.center {
+  transform: translate(-50%, -50%);
+}
+


### PR DESCRIPTION
## Summary
- create simple Cloudflare Pages PWA
- implement swipe interactions with questions for Tzar and Citizen roles
- add service worker and manifest for PWA installation
- update README with game and build info
- remove icon images and references

## Testing
- `node --version`
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_6853f65089188332ad8e5ee773113072