### PR TITLE
Add vertical navigation gestures

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # PWA Swipe Card Game
 
-This project is a simple progressive web app (PWA) built for Cloudflare Pages. The game presents a deck of cards that can be swiped left or right on mobile screens.
+This project is a simple progressive web app (PWA) built for Cloudflare Pages. The game presents a deck of cards that can be swiped left or right on mobile screens. You can also swipe up or down to move between cards during play.
 
 ## Gameplay
 1. The first card asks **"Would you like to enlist as Tzar?"**. Swipe right for yes or left for no. You must answer this card to continue.
 2. Depending on your answer, a shuffled deck of 20 questions for either **Tzar** or **Citizen** is displayed.
-3. Each card can be swiped right (yes) or left (no). After you answer, the next card slides into view.
+3. Each card can be swiped right (yes) or left (no). You may also swipe up to move forward or swipe down to return to the previous card. After you answer, the next card slides into view.
 
 ## Development
 All files are static and can be deployed directly on Cloudflare Pages.

--- a/script.js
+++ b/script.js
@@ -52,6 +52,7 @@ let index = 0;
 let state = 'intro';
 let animating = false;
 let currentSwipeDir = null;
+let targetIndex = null;
 
 const currentEl = document.getElementById('current-card');
 const nextEl = document.getElementById('next-card');
@@ -106,7 +107,13 @@ function onTransitionEnd() {
   animating = false;
   currentEl.className = 'card';
   nextEl.classList.remove('center');
-  handleAnswer(currentSwipeDir === 'right' ? 'yes' : 'no');
+  if (currentSwipeDir === 'right' || currentSwipeDir === 'left') {
+    handleAnswer(currentSwipeDir === 'right' ? 'yes' : 'no');
+  } else if (currentSwipeDir === 'up' || currentSwipeDir === 'down') {
+    index = targetIndex;
+    currentEl.textContent = deck[index];
+    prepareNext();
+  }
 }
 
 function swipe(dir) {
@@ -115,6 +122,22 @@ function swipe(dir) {
   animating = true;
   currentEl.classList.add(dir === 'right' ? 'move-right' : 'move-left');
   nextEl.classList.remove('enter-from-bottom');
+  nextEl.classList.add('center');
+}
+
+function swipeVertical(dir) {
+  if (animating || state !== 'game') return;
+  if (dir === 'up' && index >= deck.length - 1) return;
+  if (dir === 'down' && index <= 0) return;
+  currentSwipeDir = dir;
+  animating = true;
+  targetIndex = index + (dir === 'up' ? 1 : -1);
+  nextEl.textContent = deck[targetIndex];
+  nextEl.className = 'card ' + (dir === 'up' ? 'enter-from-bottom' : 'enter-from-top');
+  // force reflow to apply starting position
+  void nextEl.offsetWidth;
+  currentEl.classList.add(dir === 'up' ? 'move-up' : 'move-down');
+  nextEl.classList.remove(dir === 'up' ? 'enter-from-bottom' : 'enter-from-top');
   nextEl.classList.add('center');
 }
 
@@ -132,6 +155,8 @@ currentEl.addEventListener('pointerup', e => {
   const dy = e.clientY - startY;
   if (Math.abs(dx) > Math.abs(dy) && Math.abs(dx) > threshold) {
     swipe(dx > 0 ? 'right' : 'left');
+  } else if (Math.abs(dy) > threshold) {
+    swipeVertical(dy < 0 ? 'up' : 'down');
   }
 });
 

--- a/style.css
+++ b/style.css
@@ -51,6 +51,18 @@ html, body {
   transform: translate(150%, -50%) rotate(15deg);
 }
 
+.move-up {
+  transform: translate(-50%, -150%);
+}
+
+.move-down {
+  transform: translate(-50%, 150%);
+}
+
+.enter-from-top {
+  transform: translate(-50%, -150%);
+}
+
 .enter-from-bottom {
   transform: translate(-50%, 150%);
 }


### PR DESCRIPTION
## Summary
- allow swiping up or down between cards
- implement vertical movement animations
- document vertical navigation usage

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68540c4ef8f48332ba107855750c206b