### PR TITLE
Add buttons and fade animation for cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # PWA Swipe Card Game
 
-This project is a simple progressive web app (PWA) built for Cloudflare Pages. The game presents a deck of cards that can be swiped left or right on mobile screens. You can also swipe up or down to move between cards during play.
+This project is a simple progressive web app (PWA) built for Cloudflare Pages. The game presents a deck of cards that can be swiped left or right on mobile screens. A shuffle button lets you randomize the deck.
 
 ## Gameplay
-1. The first card asks **"Would you like to enlist as Tzar?"**. Swipe right for yes or left for no. You must answer this card to continue.
+1. The first card asks **"Would you like to enlist as Tzar?"**. Swipe right for yes or left for no, or use the yes/no buttons below the card. You must answer this card to continue.
 2. Depending on your answer, a shuffled deck of 20 questions for either **Tzar** or **Citizen** is displayed.
-3. Each card can be swiped right (yes) or left (no). You may also swipe up to move forward or swipe down to return to the previous card. After you answer, the next card slides into view.
+3. Each card can be swiped right (yes) or left (no), or answered using the buttons. The shuffle button above the card reshuffles the remaining questions. Cards fade out when answered and the next one fades in.
 
 ## Development
 All files are static and can be deployed directly on Cloudflare Pages.

--- a/index.html
+++ b/index.html
@@ -9,19 +9,13 @@
 </head>
 <body>
   <div id="app">
-    <div class="card" id="current-card">
+    <button id="shuffle-button">Shuffle</button>
+    <div class="card" id="card">
       <div class="card-text"></div>
-      <div class="labels">
-        <span class="no-label">No</span>
-        <span class="yes-label">Yes</span>
-      </div>
     </div>
-    <div class="card" id="next-card">
-      <div class="card-text"></div>
-      <div class="labels">
-        <span class="no-label">No</span>
-        <span class="yes-label">Yes</span>
-      </div>
+    <div class="btn-row">
+      <button id="no-button">No</button>
+      <button id="yes-button">Yes</button>
     </div>
   </div>
   <script src="script.js"></script>

--- a/style.css
+++ b/style.css
@@ -37,46 +37,17 @@ html, body {
   font-size: 1.3em;
   user-select: none;
   touch-action: none; /* to get pointer events */
-  transition: transform 0.25s ease-out;
+  transition: transform 0.25s ease-out, opacity 0.25s ease-out;
+  opacity: 1;
 }
 
-.hidden {
-  display: none;
-}
-
-.move-left {
-  transform: translate(-160%, -50%) rotate(-25deg);
-}
-
-.move-right {
-  transform: translate(160%, -50%) rotate(25deg);
-}
-
-.move-up {
-  transform: translate(-50%, -150%);
-}
-
-.move-down {
-  transform: translate(-50%, 150%);
-}
-
-.enter-from-top {
-  transform: translate(-50%, -150%);
-}
-
-.enter-from-bottom {
-  transform: translate(-50%, 150%);
-}
-
-.center {
-  transform: translate(-50%, -50%);
-}
 
 .card-text {
   pointer-events: none;
 }
 
-.labels {
+
+.btn-row {
   position: absolute;
   bottom: 10px;
   left: 0;
@@ -84,10 +55,20 @@ html, body {
   display: flex;
   justify-content: space-between;
   padding: 0 20px;
-  font-size: 0.9em;
-  text-transform: uppercase;
-  color: #555;
-  pointer-events: none;
-  opacity: 0.8;
+  box-sizing: border-box;
+}
+
+.btn-row button {
+  width: 45%;
+  padding: 10px;
+  font-size: 1em;
+}
+
+#shuffle-button {
+  position: absolute;
+  top: 10px;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 10px 20px;
 }
 


### PR DESCRIPTION
## Summary
- simplify card layout
- add yes/no buttons and shuffle button
- support fade animation and update swipe logic
- update styles and README

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6856f4a267c48332bdf5ed72ac32f8a6